### PR TITLE
コメント通知機能のノイズを除去

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,21 +41,16 @@ Issue Body : *${ibody}*
 [Build log here](https://github.com/${repo}/commit/${sha}/checks)`
         case "issue_comment":
             return `
-🗣🗣🗣🗣🗣🗣
+🗣🗣🗣Issueにコメントが付きました🗣🗣🗣
 
-Issue ${prstate}
+Issue : ${ititle} | #${inum}
 
-Issue Title and Number  : ${ititle} | #${inum}
+コメント内容: \`${process.env.INPUT_IU_COM}\`
 
-Commented or Created By : \`${iactor}\`
-
-Issue Body : *${ibody}*
-
-Issue Comment: \`${process.env.INPUT_IU_COM}\`
-
-[Link to Issue](https://github.com/${repo}/issues/${inum})
-[Link to Repo ](https://github.com/${repo}/)
-[Build log here](https://github.com/${repo}/commit/${sha}/checks)
+\`${iactor}\` がコメントしました
+[Issueを開く](https://github.com/${repo}/issues/${inum})
+[Repositoryを開く](https://github.com/${repo}/)
+[Build logを開く](https://github.com/${repo}/commit/${sha}/checks)
             `
         case "pull_request":
             return `


### PR DESCRIPTION
コメントがあった際にシンプルな通知のみをするように変更、ミニマリズムゥ(●'◡'●)

`case "issue_comment":`

[のcase](https://github.com/artery-app/Barulhento/blob/cf814956567e21f0c6f25a672c8024df438bb388/index.js#L44)において、なぜかcreateを前提にした文言も含まれていたため削除
また、いちいちコメントのたびにissueのbodyを表示するのはnoizy(リンク先で確認しろ)と感じたので削除